### PR TITLE
:sparkles: Add getter to ModuleRegistry to get specific service by module name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openreplyde/web-docker",
-  "version": "1.0.0-alpha.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@openreplyde/web-docker",
-      "version": "1.0.0-alpha.1",
+      "version": "1.4.0",
       "devDependencies": {
         "@playwright/test": "1.29.0",
         "@testing-library/dom": "^8.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openreplyde/web-docker",
-  "version": "1.3.0-alpha.6",
+  "version": "1.4.0",
   "type": "module",
   "files": [
     "dist"

--- a/src/core/ModuleRegistry.spec.ts
+++ b/src/core/ModuleRegistry.spec.ts
@@ -133,4 +133,32 @@ describe("ModuleRegistry", () => {
 
     expect(document.body).toMatchSnapshot();
   });
+
+  it("does return service by name", async () => {
+    // Setup test
+    const assetFactoryMock: AssetFactory = {
+      create(): (HTMLLinkElement | HTMLScriptElement)[] {
+        return [document.createElement("link")];
+      },
+    };
+    const moduleRegistry = new ModuleRegistry(false, assetFactoryMock);
+
+    const service = await moduleRegistry.add(config);
+    // End test setup
+
+    expect(moduleRegistry.getByModuleName(config.module)).toEqual(service);
+  });
+
+  it("throws when requested service does not exist in registry", async () => {
+    // Setup test
+    const assetFactoryMock: AssetFactory = {
+      create(): (HTMLLinkElement | HTMLScriptElement)[] {
+        return [document.createElement("link")];
+      },
+    };
+    const moduleRegistry = new ModuleRegistry(false, assetFactoryMock);
+    // End test setup
+
+    expect(() => moduleRegistry.getByModuleName("invalid-module-name")).toThrowError("A module with name: invalid-module-name has not been registered.");
+  });
 });

--- a/src/core/ModuleRegistry.ts
+++ b/src/core/ModuleRegistry.ts
@@ -8,6 +8,7 @@ import { ObservedModuleService } from "~/core/ObservedModuleService";
 
 export interface ModuleRegistryInterface {
   add(config: Config): Promise<ModuleService>;
+  getByModuleName(moduleName: string): ModuleService
 }
 
 export interface ModuleServiceConstructor {
@@ -28,6 +29,17 @@ class ModuleRegistry implements ModuleRegistryInterface {
     private readonly assetFactory = new AssetFactory()
   ) {
     this.logger = new Logger("ModuleRegistry", logEvents);
+  }
+
+  getByModuleName(moduleName: string): ModuleService {
+    const service = this.moduleServices.find(
+      (moduleService) => moduleService.module && moduleService.module === moduleName
+    );
+    if (!service) {
+      throw Error(`A module with name: ${moduleName} has not been registered.`);
+    }
+
+    return service;
   }
 
   add(config: ModuleConfig): Promise<ModuleService> {

--- a/src/core/PageModuleService.ts
+++ b/src/core/PageModuleService.ts
@@ -1,12 +1,10 @@
 import AssetFactory, { HtmlAsset } from "./AssetFactory";
 import { Logger } from "~/core/Logger";
 import type {
-  IncludeType,
   PageInclude,
   PageModuleConfig,
 } from "~/core/ModuleConfig";
 import { ModuleService } from "~/core/ModuleService";
-import { HTMLScriptElement } from "happy-dom";
 import { forEachSeries } from "~/core/utils";
 
 class PageModuleService implements ModuleService {


### PR DESCRIPTION
This PR adds getter to the module registry to obtain the service by module name. 